### PR TITLE
typescript required for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 COPY package*.json /app/
 RUN npm install --production
+RUN npm install --save-dev typescript @types/react @types/node
 
 COPY ./ ./next.config.js /app/
 RUN npm run build


### PR DESCRIPTION
Using npm install --production prevents the devDependencies to be ignored. But next build requires it! *yak shaving* 